### PR TITLE
Fix MMS data profile

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -87,5 +87,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # RIL
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.multisim.simslotcount=2 \
+    ro.telephony.mms_data_profile=5 \
     rild.libpath=/system/lib64/libsec-ril.so \
     rild.libpath2=/system/lib64/libsec-ril-dsds.so


### PR DESCRIPTION
See [https://review.lineageos.org/#/c/71724/](https://review.lineageos.org/#/c/71724/).

Tested with Sonera Finland where MMS uses a separate APN from LTE and there's no access to the MMSC from the Internet.

EDIT: This has been applied successfully to jflte and klte as well, seems to be a Samsung specific thing.