### PR TITLE
Couple interactive mode to display state

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -232,10 +232,6 @@
     <!-- Permit doze mode to operate -->
     <bool name="config_enableAutoPowerModes">true</bool>
 
-    <!-- Power Management: Specifies whether to decouple the interactive state of the
-         device from the display on/off state. -->
-    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
-
     <!-- Allow screen mirroring/miracast -->
     <bool name="config_enableWifiDisplay">true</bool>
     <!-- Our gralloc has support for protected buffers -->


### PR DESCRIPTION
This commit fixes the touchscreen interactivity with for example `PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK`. The MM kernel nor the NN kernel disable the touchscreen when `FB_BLANK_POWERDOWN` is requested and thus the interactive mode should be coupled with the display state (for now at least).