### PR TITLE
hero: enable BLE peripheral mode

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -57,6 +57,9 @@
         <item>"7,1"</item>
     </string-array>
 
+	<!-- Boolean indicating if current platform supports BLE peripheral mode -->
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+
     <!-- List of regexpressions describing the interface (if any) that represent tetherable
          USB interfaces.  If the device doesn't want to support tething over USB this should
          be empty.  An example would be "usb.*" -->


### PR DESCRIPTION
My KEVO needs this function to use the Touch To Open feature.  Other devices might need it for similar features.