### PR TITLE
selinux: more permissions for camera

### DIFF
--- a/sepolicy/cameraserver.te
+++ b/sepolicy/cameraserver.te
@@ -7,3 +7,5 @@ allow cameraserver camera_device:chr_file { read open getattr };
 allow camera_device sysfs:filesystem associate;
 
 allow cameraserver camera_data_file:file { read open };
+
+allow cameraserver media_rw_data_file:dir search;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -25,6 +25,8 @@
 /dev/v4l-subdev[0-9]*        u:object_r:video_device:s0
 /dev/media[0-3]*             u:object_r:camera_device:s0
 /dev/m2m1shot_jpeg           u:object_r:camera_device:s0
+/dev/m2m1shot_scaler0        u:object_r:video_device:s0
+/dev/m2m1shot_scaler1        u:object_r:video_device:s0
 
 /dev/mtp_usb*                u:object_r:mtp_device:s0
 


### PR DESCRIPTION
After your recent changes I noticed some AVC denials from logcat.
These adjustments to sepolicy fix those denials and allow Snapchat videos to be recorded.