### PR TITLE
TEMP - Set vibrate intensity and fix rotation

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -272,4 +272,14 @@
 
     <!-- Boolean indicating if current platform supports BLE peripheral mode -->
     <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+    
+    <!-- Vibrator pattern for a very short but reliable vibration for soft keyboard tap -->
+    <integer-array name="config_keyboardTapVibePattern">
+        <item>10</item>
+    </integer-array>
+    
+    <!-- Certain sensor firmwares break with having a batch
+     size set. By setting this to false, devices can opt
+     out of setting a batch size, which fixes rotation. -->
+    <bool name="config_useDefaultBatchingForAccel">false</bool>
 </resources>

--- a/overlay/frameworks/base/packages/Keyguard/res/values/config.xml
+++ b/overlay/frameworks/base/packages/Keyguard/res/values/config.xml
@@ -23,4 +23,9 @@
     <!-- Threshold in micro watts below which a charger is rated as "slow"; 1A @ 5V -->
     <integer name="config_chargingSlowlyThreshold">0</integer>
 
+    <!-- Should we listen for fingerprints when the screen is off?  Devices
+         with a rear-mounted sensor want this, but certain devices have
+         the sensor embedded in the power key and listening all the time
+         causes a poor experience. -->
+    <bool name="config_fingerprintWakeAndUnlock">false</bool>
 </resources>


### PR DESCRIPTION
On hero while typing, vibration intensity provides more feedback than on stock, this sets the value to be lower. Also set no batch size to fix screen rotation.

This is meant for a workaround as I know we are on nougat blobs just providing until a better solution comes around :)