### PR TITLE
hero: Lockscreen charging info -> real time values

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -67,3 +67,6 @@ BOARD_SEPOLICY_DIRS := device/samsung/hero-common/sepolicy
 
 # Inherit from the proprietary version
 -include vendor/samsung/hero-common/BoardConfigVendor.mk
+
+#Lockscreen charging info: real time values 
+BOARD_GLOBAL_CFLAGS += -DBATTERY_REAL_INFO 


### PR DESCRIPTION
Useful to show for example on RR the real time charging current 
Refference: https://github.com/ResurrectionRemix/system_core/commit/5c0fc72c13f31d2d439cd843268277f414befad6