### PR TITLE
hero: show the AutoBrightness checkbox

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -27,4 +27,7 @@
 
     <!-- Doze: does this device support STATE_DOZE and STATE_DOZE_SUSPEND?  -->
     <bool name="doze_display_state_supported">true</bool>
+     
+    <!-- When true,show the AutoBrightness checkbox -->
+    <bool name="config_show_auto_brightness">true</bool>
 </resources>


### PR DESCRIPTION
put AutoBrightness checkbox near brightness slider in QSPanel, which can turn on and off the Adaptive brightness function similar with Settings->Display->Adaptive brightness.