### PR TITLE
hero: set charging values and switch to stock fingerprint behavior

### DIFF
--- a/overlay/frameworks/base/packages/Keyguard/res/values/config.xml
+++ b/overlay/frameworks/base/packages/Keyguard/res/values/config.xml
@@ -20,7 +20,16 @@
 <!-- These resources are around just to allow their values to be customized -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <!-- Threshold in micro watts below which a charger is rated as "slow"; 1A @ 5V -->
-    <integer name="config_chargingSlowlyThreshold">0</integer>
+<!-- Threshold in micro watts below which a charger is rated as "slow"; 1A @ 5V -->
+<integer name="config_chargingSlowlyThreshold">1000000</integer>
+
+<!-- Threshold in micro watts above which a charger is rated as "fast"; 1.5A @ 5V  -->
+<integer name="config_chargingFastThreshold">1500000</integer>
+
+<!-- Should we listen for fingerprints when the screen is off?  Devices
+     with a rear-mounted sensor want this, but certain devices have
+     the sensor embedded in the power key and listening all the time
+     causes a poor experience. -->
+<bool name="config_fingerprintWakeAndUnlock">false</bool>
 
 </resources>


### PR DESCRIPTION
1. charger values for slow and fast charging
2. fingerprint should listen only when screen is on (like on stock - prevents wrong validation in some cases when you take the phone out of pocket by the home button)